### PR TITLE
Add slack invitation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # [athtech.github.io](http://athtech.org)
 
+[![slack](http://athtech.zorbash.com/badge.svg)](http://athtech.zorbash.com/)
+
 Athens's tech and developer Events, Meetups & News.
 
 ## Meetup Organizers

--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@ layout: frontpage
             <li>
               <div class="fb-like" data-href="https://www.facebook.com/athtech.org" data-layout="button_count" data-action="like" data-show-faces="false" data-share="false" data-width="200"></div>
             </li>
+            <li>
+              <script async defer src="http://athtech.zorbash.com/slackin.js"></script>
+            </li>
           </ul>
         </div>
     	</div>


### PR DESCRIPTION
A [slackin](https://github.com/rauchg/slackin) instance has been deployed on athtech.zorbash.com.
Slackin provides a badge which this commit adds to our index page.

Changes:
![selection_109](https://cloud.githubusercontent.com/assets/645514/13548967/0efc75d2-e305-11e5-9952-e2df064c32f5.png)

![selection_111](https://cloud.githubusercontent.com/assets/645514/13548977/47d3face-e305-11e5-8d9a-5bac5d8c91b4.png)

Currently the badges are served from athtech.zorbash.com which also an landing invitation page.

![selection_112](https://cloud.githubusercontent.com/assets/645514/13548986/725283f6-e305-11e5-94ca-5cd6ab48195a.png)

![selection_113](https://cloud.githubusercontent.com/assets/645514/13549076/02de1678-e307-11e5-941d-64195725f027.png)

> Domain owners of athtech.org are welcome to add a CNAME to athtech.zorbash.com.
